### PR TITLE
Fix vertical positioning of task items

### DIFF
--- a/app/src/main/res/layout/task_item.xml
+++ b/app/src/main/res/layout/task_item.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
 
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/item_layout"
     android:orientation="horizontal"
     android:layout_width="match_parent"
@@ -10,7 +10,6 @@
     android:background="@drawable/list_item_selector"
     >
 
-
 <CheckBox
     android:layout_width="wrap_content"
     android:layout_height="50dp"
@@ -18,34 +17,46 @@
     android:id="@+id/taskCheckBox"
     android:onClick="onTaskChecked"
     android:layout_centerVertical="true"
-   />
-<TextView
+    />
 
+<RelativeLayout
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:id = "@+id/task_item_task_desc"
-    android:textAppearance="?android:textAppearanceMedium"
-    android:text = "TEST"
+    android:minHeight="50dp"
+    android:gravity="center_vertical"
     android:layout_toRightOf="@id/taskCheckBox"
-    android:layout_alignTop="@id/taskCheckBox"/>
+    >
 
-<TextView
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:id = "@+id/task_item_task_date"
-    android:textAppearance="?android:textAppearanceSmall"
-    android:text = "TEST"
-    android:layout_below="@id/task_item_task_desc"
-    android:layout_toRightOf="@id/taskCheckBox" />
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id = "@+id/task_item_task_desc"
+        android:textAppearance="?android:textAppearanceMedium"
+        android:text = "Task Name"
+        android:orientation="vertical"
+        android:layout_gravity="bottom"
+        />
 
-<View
-    android:id = "@+id/priorityBar"
-    android:layout_width="20dp"
-    android:layout_height="wrap_content"
-    android:layout_alignParentRight = "true"
-    android:layout_alignBottom="@id/task_item_task_date"/>
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:id = "@+id/task_item_task_date"
+        android:textAppearance="?android:textAppearanceSmall"
+        android:text = "Date"
+        android:layout_below="@id/task_item_task_desc"
+        android:layout_gravity="top"
+        />
+
+    <View
+        android:id = "@+id/priorityBar"
+        android:layout_width="20dp"
+        android:layout_height="wrap_content"
+        android:layout_alignParentRight = "true"
+        android:layout_alignBottom="@id/task_item_task_date"
+        />
     <!--android:background="@android:color/holo_red_dark"-->
 
-
+</RelativeLayout>
 
 </RelativeLayout>


### PR DESCRIPTION
This merge request should vertically centre task items without a date.

Since the XML diff is terrible, the key idea boils down to [this](http://stackoverflow.com/a/18051534).

I couldn't test the priority bar because I wasn't sure how to get it to appear. Was it working before?

![positioning](https://cloud.githubusercontent.com/assets/12449414/23595354/220a237c-01d6-11e7-9175-dac3fd679994.png)